### PR TITLE
Added Quickstart (Windows 11, using Scoop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,26 @@
 
 # Scoop website
 
-## Quickstart
-
-_On Windows 11, using [Scoop](https://scoop.sh/)_
-```powershell
-# Prerequisites
-scoop install git
-scoop install nodejs
-npm update
-
-# get repo
-git clone https://github.com/ScoopInstaller/scoopinstaller.github.io.git
-cd scoopinstaller.github.io
-
-# Install React locally to the repo
-npm install react-scripts
-
-# Start, probably localhost port 3000/5000
-npm start
-```
-
 This repository is used to build the Scoop website https://scoopinstaller.github.io
 
 
 ### Build this project
 
+#### Get the source
+- If you already use Scoop, install Git and clone the repository:
+```
+scoop install git
+git clone https://github.com/ScoopInstaller/scoopinstaller.github.io
+cd scoopinstaller.github.io
+```
+
 #### Prerequisites
-- Install a recent [Node](https://nodejs.org/en/ "Node") version >= 16.0.0
+- Install a recent [Node](https://nodejs.org/en/ "Node") version >= 16.0.0, e.g. `scoop install nodejs`
 - Run `npm update`
-- Get `react-scripts` as well: `npm install react-scripts -save`
 
 #### Launch the application
 - Run `npm start`
+
 Application should run on http://localhost:3000 or https://localhost:5000 to pass CORS checks and query the search database.
 
 #### Build the application

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 
 # Scoop website
 
+## Quickstart
+
+_On Windows 11, using [Scoop](https://scoop.sh/)_
+```powershell
+# Prerequisites
+scoop install git
+scoop install nodejs
+npm update
+npm install react-scripts -save
+
+# get repo
+git clone https://github.com/ScoopInstaller/scoopinstaller.github.io.git
+cd scoopinstaller.github.io
+
+# run site on your local machine
+npm start
+```
+
 This repository is used to build the Scoop website https://scoopinstaller.github.io
 
 
@@ -9,6 +27,7 @@ This repository is used to build the Scoop website https://scoopinstaller.github
 #### Prerequisites
 - Install a recent [Node](https://nodejs.org/en/ "Node") version >= 16.0.0
 - Run `npm update`
+- Get `react-scripts` as well: `npm install react-scripts -save`
 
 #### Launch the application
 - Run `npm start`

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ _On Windows 11, using [Scoop](https://scoop.sh/)_
 scoop install git
 scoop install nodejs
 npm update
-npm install react-scripts -save
 
 # get repo
 git clone https://github.com/ScoopInstaller/scoopinstaller.github.io.git
 cd scoopinstaller.github.io
 
-# run site on your local machine
+# Install React locally to the repo
+npm install react-scripts
+
+# Start, probably localhost port 3000/5000
 npm start
 ```
 


### PR DESCRIPTION
This PR adds a short Quickstart section that people on Windows 11 using Scoop can copy-and-paste into a Windows Terminal to quickly get the scoop.sh **website** built and running on `localhost`.

I have had success with this kind of Quickstart in [a previous project](https://github.com/hiAndrewQuinn/resorter) and thought it may be helpful, especially to people who are not used to NodeJS or NPM.