### PR TITLE
Add details popup and store an id in the query string to share a specific result

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "prettier.printWidth": 120,
   "editor.rulers": [120],
   "typescript.tsc.autoDetect": "off",
-  "npm.autoDetect": "off"
+  "npm.autoDetect": "off",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -144,3 +144,8 @@ html.dark .sorting-filtering-menu > .dropdown-item:active {
 html.dark .bg-light {
   background-color: rgba(var(--bs-dark-rgb),var(--bs-bg-opacity)) !important;
 }
+
+.modal-app-details > .modal-dialog > .modal-content {
+  background: transparent;
+  border: transparent;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -145,7 +145,7 @@ html.dark .bg-light {
   background-color: rgba(var(--bs-dark-rgb),var(--bs-bg-opacity)) !important;
 }
 
-.modal-app-details > .modal-dialog > .modal-content {
+.modal-selected-result > .modal-dialog > .modal-content {
   background: transparent;
   border: transparent;
 }

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -23,10 +23,11 @@ type SearchResultProps = {
   result: ManifestJson;
   officialRepositories: { [key: string]: string };
   onCopyToClipbard: (content: string) => void;
+  onAppSelected?: (app: ManifestJson) => void;
 };
 
 const SearchResult = (props: SearchResultProps): JSX.Element => {
-  const { result, officialRepositories, onCopyToClipbard } = props;
+  const { result, officialRepositories, onCopyToClipbard, onAppSelected } = props;
   const homepageRef = useRef<HTMLSpanElement>(null);
   const [homepageTooltipHidden, setHomepageTooltipHidden] = useState<boolean>(false);
 
@@ -35,6 +36,16 @@ const SearchResult = (props: SearchResultProps): JSX.Element => {
       onCopyToClipbard(content);
     },
     [onCopyToClipbard]
+  );
+
+  const handleAppSelected = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>): void => {
+      e.preventDefault();
+      if (onAppSelected) {
+        onAppSelected(result);
+      }
+    },
+    [onAppSelected, result]
   );
 
   const displayInnerHtml = (content?: string) => {
@@ -122,7 +133,14 @@ const SearchResult = (props: SearchResultProps): JSX.Element => {
         <Row>
           <Col lg={7} className="valign-items">
             {favicon && <Img className="me-2" src={favicon} width={20} height={20} />}
-            <span className="fw-bold">{displayInnerHtml(highlightedName)}</span>
+            <span className="fw-bold">
+              {onAppSelected && (
+                <a href="#" onClick={handleAppSelected}>
+                  {displayInnerHtml(highlightedName)}
+                </a>
+              )}
+              {!onAppSelected && displayInnerHtml(highlightedName)}
+            </span>
             <span className="me-1 ms-1">in</span>
             <a href={metadata.repository}>{displayInnerHtml(formattedHighlightedRepository)}</a>
             <BucketTypeIcon className="ms-1" official={metadata.repositoryOfficial} stars={metadata.stars} />

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -23,11 +23,12 @@ type SearchResultProps = {
   result: ManifestJson;
   officialRepositories: { [key: string]: string };
   onCopyToClipbard: (content: string) => void;
-  onAppSelected?: (app: ManifestJson) => void;
+  onResultSelected?: (result: ManifestJson) => void;
+  cardRef?: React.RefObject<HTMLDivElement>;
 };
 
 const SearchResult = (props: SearchResultProps): JSX.Element => {
-  const { result, officialRepositories, onCopyToClipbard, onAppSelected } = props;
+  const { result, officialRepositories, onCopyToClipbard, onResultSelected, cardRef } = props;
   const homepageRef = useRef<HTMLSpanElement>(null);
   const [homepageTooltipHidden, setHomepageTooltipHidden] = useState<boolean>(false);
 
@@ -38,15 +39,9 @@ const SearchResult = (props: SearchResultProps): JSX.Element => {
     [onCopyToClipbard]
   );
 
-  const handleAppSelected = useCallback(
-    (e: React.MouseEvent<HTMLAnchorElement>): void => {
-      e.preventDefault();
-      if (onAppSelected) {
-        onAppSelected(result);
-      }
-    },
-    [onAppSelected, result]
-  );
+  const handleSelected = useCallback((): void => {
+    onResultSelected?.call(this, result);
+  }, [onResultSelected, result]);
 
   const displayInnerHtml = (content?: string) => {
     return (
@@ -128,18 +123,13 @@ const SearchResult = (props: SearchResultProps): JSX.Element => {
     : `${Utils.extractPathFromUrl(metadata.repository, '_')} ${metadata.repository}`;
 
   return (
-    <Card key={id} className="mb-2">
+    <Card key={id} className="mb-2" ref={cardRef}>
       <Card.Header>
         <Row>
           <Col lg={7} className="valign-items">
             {favicon && <Img className="me-2" src={favicon} width={20} height={20} />}
-            <span className="fw-bold">
-              {onAppSelected && (
-                <a href="#" onClick={handleAppSelected}>
-                  {displayInnerHtml(highlightedName)}
-                </a>
-              )}
-              {!onAppSelected && displayInnerHtml(highlightedName)}
+            <span className="fw-bold" role={onResultSelected ? 'button' : undefined} onClick={handleSelected}>
+              {displayInnerHtml(highlightedName)}
             </span>
             <span className="me-1 ms-1">in</span>
             <a href={metadata.repository}>{displayInnerHtml(formattedHighlightedRepository)}</a>


### PR DESCRIPTION
Fix #47 

- Details popup is displayed when result name is clicked
- Result id is stored in the query string
- Details popup is displayed when a result id is found in the query string (useful when an URL is shared)

![Cia7Xk4RlG](https://user-images.githubusercontent.com/3621529/214475753-aa94e1bb-d673-4d4f-9b7d-bd3920bb1a29.gif)
