### PR TITLE
Respect URL params & display correct bucket content

### DIFF
--- a/src/components/Buckets.tsx
+++ b/src/components/Buckets.tsx
@@ -167,7 +167,7 @@ const Buckets = (): JSX.Element => {
                         <Link
                           to={{
                             pathname: '/apps',
-                            search: `?q="${encodeURIComponent(item.bucket)}"`,
+                            search: `?q="${encodeURIComponent(item.bucket)}"${item.official ? '' : '&o=false'}`,
                           }}
                         >
                           {Utils.extractPathFromUrl(item.bucket)}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -127,10 +127,12 @@ const Search = (): JSX.Element => {
   }, [getCurrentPageFromSearchParams]);
 
   useEffect(() => {
-    updateSearchParams(SEARCH_PARAM_SORT_INDEX, sortIndex.toString(), true);
-    updateSearchParams(SEARCH_PARAM_SORT_DIRECTION, sortDirection.toString(), true);
-    updateSearchParams(SEARCH_PARAM_FILTER_OFFICIALONLY, searchOfficialOnly.toString(), true);
-  }, [updateSearchParams, sortIndex, sortDirection, searchOfficialOnly]);
+    const sortIndexFromUrl = getSortIndexFromSearchParams();
+    const sortDirectionFromUrl = getSortDirectionFromSearchParams(sortIndexFromUrl);
+    setSortIndex(sortIndexFromUrl);
+    setSortDirection(sortDirectionFromUrl);
+    setSearchOfficialOnly(getSearchOfficialOnlyFromSearchParams());
+  }, [getSortIndexFromSearchParams, getSortDirectionFromSearchParams, getSearchOfficialOnlyFromSearchParams]);
 
   useEffect(() => {
     if (searchResults?.results && selectedResultId) {
@@ -190,11 +192,14 @@ const Search = (): JSX.Element => {
   );
 
   const handleSortChange = (newSortIndex: number, newSortDirection: SortDirection): void => {
+    updateSearchParams(SEARCH_PARAM_SORT_INDEX, newSortIndex.toString(), true);
+    updateSearchParams(SEARCH_PARAM_SORT_DIRECTION, newSortDirection.toString(), true);
     setSortIndex(newSortIndex);
     setSortDirection(newSortDirection);
   };
 
   const handleSearchOfficialOnlyChange = (newSearchOfficialOnly: boolean): void => {
+    updateSearchParams(SEARCH_PARAM_FILTER_OFFICIALONLY, newSearchOfficialOnly.toString(), true);
     setSearchOfficialOnly(newSearchOfficialOnly);
   };
 


### PR DESCRIPTION
Closes #55

This commit addresses two main issues in the search and bucket components. Firstly, it ensures that search parameters from the URL are respected, and secondly, it allows correct display of bucket content when clicking on non-official repositories.

Changes made:

1. In Search.tsx, modified the code to read and set sortIndex, sortDirection, and searchOfficialOnly from the URL parameters using getSortIndexFromSearchParams, getSortDirectionFromSearchParams, and getSearchOfficialOnlyFromSearchParams, respectively.
2. Updated handleSortChange and handleSearchOfficialOnlyChange to set the respective state variables directly, instead of updating the URL parameters first.
3. In Buckets.tsx, changed the 'search' property of the 'Link' component to include the official flag in the query parameters, ensuring that the bucket content is displayed correctly for non-official repositories.