### PR TITLE
Add option to display bucket name in install command

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -4,13 +4,13 @@ import { Container, Row, Col, Modal } from 'react-bootstrap';
 import { Helmet } from 'react-helmet';
 import { useSearchParams } from 'react-router-dom';
 
-import { requestIdleCallback } from '../request-idle-callback';
-import ManifestJson from '../serialization/ManifestJson';
-import SearchResultsJson from '../serialization/SearchResultsJson';
 import SearchBar from './SearchBar';
 import SearchPagination from './SearchPagination';
 import SearchProcessor, { SortDirection, sortModes } from './SearchProcessor';
 import SearchResult from './SearchResult';
+import { requestIdleCallback } from '../request-idle-callback';
+import ManifestJson from '../serialization/ManifestJson';
+import SearchResultsJson from '../serialization/SearchResultsJson';
 
 const RESULTS_PER_PAGE = 20;
 const SEARCH_PARAM_QUERY = 'q';
@@ -18,6 +18,7 @@ const SEARCH_PARAM_PAGE = 'p';
 const SEARCH_PARAM_SORT_INDEX = 's';
 const SEARCH_PARAM_SORT_DIRECTION = 'd';
 const SEARCH_PARAM_FILTER_OFFICIALONLY = 'o';
+const SEARCH_PARAM_OPTION_BUCKETNAME = 'n';
 const SEARCH_PARAM_SELECTED_RESULT = 'id';
 const SEARCH_DEBOUNCE_TIME_IN_MS = 500;
 
@@ -80,6 +81,10 @@ const Search = (): JSX.Element => {
     return getSearchParam(SEARCH_PARAM_FILTER_OFFICIALONLY, true);
   }, [getSearchParam]);
 
+  const getInstallBucketNameFromSearchParams = useCallback((): boolean => {
+    return getSearchParam(SEARCH_PARAM_OPTION_BUCKETNAME, true);
+  }, [getSearchParam]);
+
   const getSelectedResultFromSearchParams = useCallback((): string => {
     return getSearchParam<string>(SEARCH_PARAM_SELECTED_RESULT, '');
   }, [getSearchParam]);
@@ -110,6 +115,8 @@ const Search = (): JSX.Element => {
   const [sortIndex, setSortIndex] = useState<number>(getSortIndexFromSearchParams);
   const [sortDirection, setSortDirection] = useState<SortDirection>(getSortDirectionFromSearchParams(sortIndex));
   const [searchOfficialOnly, setSearchOfficialOnly] = useState<boolean>(getSearchOfficialOnlyFromSearchParams);
+  const [installBucketName, setInstallBucketName] = useState<boolean>(getInstallBucketNameFromSearchParams());
+
   const [searchResults, setSearchResults] = useState<SearchResultsJson>();
   const [officialRepositories, setOfficialRepositories] = useState<{ [key: string]: string }>({});
   const [selectedResult, setSelectedResult] = useState<ManifestJson | null>();
@@ -126,11 +133,19 @@ const Search = (): JSX.Element => {
     setCurrentPage(getCurrentPageFromSearchParams());
   }, [getCurrentPageFromSearchParams]);
 
-  useEffect(() => {
-    updateSearchParams(SEARCH_PARAM_SORT_INDEX, sortIndex.toString(), true);
-    updateSearchParams(SEARCH_PARAM_SORT_DIRECTION, sortDirection.toString(), true);
-    updateSearchParams(SEARCH_PARAM_FILTER_OFFICIALONLY, searchOfficialOnly.toString(), true);
-  }, [updateSearchParams, sortIndex, sortDirection, searchOfficialOnly]);
+  if (getSortIndexFromSearchParams() !== sortIndex) {
+    setSortIndex(getSortIndexFromSearchParams());
+  }
+  if (getSortDirectionFromSearchParams(getSortIndexFromSearchParams()) !== sortDirection) {
+    setSortIndex(getSortDirectionFromSearchParams(getSortIndexFromSearchParams()));
+  }
+  if (getSearchOfficialOnlyFromSearchParams() !== searchOfficialOnly) {
+    setSearchOfficialOnly(getSearchOfficialOnlyFromSearchParams());
+  }
+
+  if (getInstallBucketNameFromSearchParams() !== installBucketName) {
+    setInstallBucketName(getInstallBucketNameFromSearchParams());
+  }
 
   useEffect(() => {
     if (searchResults?.results && selectedResultId) {
@@ -214,6 +229,15 @@ const Search = (): JSX.Element => {
     setSelectedResultId('');
   }, []);
 
+  const handleInstallBucketName = useCallback(
+    (newInstallBucketName: boolean): void => {
+      updateSearchParams(SEARCH_PARAM_OPTION_BUCKETNAME, newInstallBucketName.toString(), true);
+
+      setInstallBucketName(newInstallBucketName);
+    },
+    [updateSearchParams]
+  );
+
   return (
     <>
       <Helmet>
@@ -239,6 +263,8 @@ const Search = (): JSX.Element => {
               onResultsChange={handleResultsChange}
               onSortChange={handleSortChange}
               onSearchOfficialOnlyChange={handleSearchOfficialOnlyChange}
+              installBucketName={installBucketName}
+              onInstallBucketName={handleInstallBucketName}
             />
           </Col>
         </Row>
@@ -253,6 +279,8 @@ const Search = (): JSX.Element => {
                 officialRepositories={officialRepositories}
                 onCopyToClipbard={handleCopyToClipboard}
                 onResultSelected={handleResultSelected}
+                installBucketName={installBucketName}
+                onInstallBucketName={handleInstallBucketName}
               />
             ))}
           </Col>
@@ -284,6 +312,8 @@ const Search = (): JSX.Element => {
               result={selectedResult}
               officialRepositories={officialRepositories}
               onCopyToClipbard={handleCopyToClipboard}
+              installBucketName={installBucketName}
+              onInstallBucketName={handleInstallBucketName}
             />
           )}
         </Modal.Body>

--- a/src/components/SearchProcessor.tsx
+++ b/src/components/SearchProcessor.tsx
@@ -5,9 +5,9 @@ import { IconBaseProps } from 'react-icons';
 import { FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa';
 import { GoSettings } from 'react-icons/go';
 
-import SearchResultsJson from '../serialization/SearchResultsJson';
 import BucketTypeIcon from './BucketTypeIcon';
 import SearchStatus, { SearchStatusType } from './SearchStatus';
+import SearchResultsJson from '../serialization/SearchResultsJson';
 
 export enum SortDirection {
   Ascending,
@@ -26,6 +26,10 @@ type SearchProcessorProps = {
   sortIndex: number;
   sortDirection: SortDirection;
   searchOfficialOnly: boolean;
+
+  installBucketName: boolean;
+  onInstallBucketName: (installBucketName: boolean) => void;
+
   resultsPerPage: number;
   onResultsChange: (value?: SearchResultsJson) => void;
   onSortChange: (sortIndex: number, sortDirection: SortDirection) => void;
@@ -93,6 +97,8 @@ const SearchProcessor = (props: SearchProcessorProps): JSX.Element => {
     onResultsChange,
     onSortChange,
     onSearchOfficialOnlyChange,
+    installBucketName,
+    onInstallBucketName,
   } = props;
 
   const handleSortChange = useCallback(
@@ -108,6 +114,14 @@ const SearchProcessor = (props: SearchProcessorProps): JSX.Element => {
       onSearchOfficialOnlyChange(!searchOfficialOnly);
     },
     [searchOfficialOnly, onSearchOfficialOnlyChange]
+  );
+
+  const toggleInstallBucketName = useCallback(
+    (e: React.MouseEvent<HTMLElement>): void => {
+      e.currentTarget.blur();
+      onInstallBucketName(!installBucketName);
+    },
+    [installBucketName, onInstallBucketName]
   );
 
   const toggleSort = useCallback(
@@ -267,6 +281,15 @@ const SearchProcessor = (props: SearchProcessorProps): JSX.Element => {
                   <Form.Switch.Label>
                     Official buckets only <BucketTypeIcon className="ms-1" official showTooltip={false} />
                   </Form.Switch.Label>
+                </Form.Switch>
+              </Dropdown.Item>
+
+              <Dropdown.Divider />
+              <Dropdown.Header>Option</Dropdown.Header>
+              <Dropdown.Item as={Button} onClick={(e) => toggleInstallBucketName(e)}>
+                <Form.Switch className="form-switch-sm">
+                  <Form.Switch.Input checked={installBucketName} />
+                  <Form.Switch.Label>Show bucket name</Form.Switch.Label>
                 </Form.Switch>
               </Dropdown.Item>
             </Dropdown.Menu>

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -9,10 +9,10 @@ import { Img } from 'react-image';
 import deprecatedSpdxLicenses from 'spdx-license-ids/deprecated.json';
 import supportedSpdxLicenses from 'spdx-license-ids/index.json';
 
-import ManifestJson from '../serialization/ManifestJson';
-import Utils from '../utils';
 import BucketTypeIcon from './BucketTypeIcon';
 import CopyToClipboardButton from './CopyToClipboardButton';
+import ManifestJson from '../serialization/ManifestJson';
+import Utils from '../utils';
 
 const spdxLicenses = supportedSpdxLicenses.concat(deprecatedSpdxLicenses);
 
@@ -25,10 +25,13 @@ type SearchResultProps = {
   onCopyToClipbard: (content: string) => void;
   onResultSelected?: (result: ManifestJson) => void;
   cardRef?: React.RefObject<HTMLDivElement>;
+
+  installBucketName: boolean;
+  onInstallBucketName: (installBucketName: boolean) => void;
 };
 
 const SearchResult = (props: SearchResultProps): JSX.Element => {
-  const { result, officialRepositories, onCopyToClipbard, onResultSelected, cardRef } = props;
+  const { result, officialRepositories, onCopyToClipbard, onResultSelected, cardRef, installBucketName } = props;
   const homepageRef = useRef<HTMLSpanElement>(null);
   const [homepageTooltipHidden, setHomepageTooltipHidden] = useState<boolean>(false);
 
@@ -117,10 +120,13 @@ const SearchResult = (props: SearchResultProps): JSX.Element => {
 
   const versionPrefix = version.length > 0 && /^\d/.test(version) && 'v';
 
-  const bucketCommandLine = metadata.repositoryOfficial
-    ? (officialRepositories[metadata.repository] && officialRepositories[metadata.repository]) ||
+  const bucketName = metadata.repositoryOfficial
+    ? officialRepositories[metadata.repository] ||
       metadata.repository.substring(metadata.repository.lastIndexOf('/') + 1).toLowerCase()
-    : `${Utils.extractPathFromUrl(metadata.repository, '_')} ${metadata.repository}`;
+    : `${Utils.extractPathFromUrl(metadata.repository, '_')}`;
+  const bucketUrl = metadata.repositoryOfficial ? '' : `${metadata.repository}`;
+  console.log(bucketName, bucketUrl);
+  const bucketCommandLine = `${bucketName} ${bucketUrl}`.trim();
 
   return (
     <Card key={id} className="mb-2" ref={cardRef}>
@@ -189,7 +195,10 @@ const SearchResult = (props: SearchResultProps): JSX.Element => {
                 <CopyToClipboardComponent value={`scoop bucket add ${bucketCommandLine}`} id="bucket-command" />
               </Row>
               <Row className="mt-2">
-                <CopyToClipboardComponent value={`scoop install ${name}`} id="app-command" />
+                <CopyToClipboardComponent
+                  value={`scoop install ${installBucketName ? bucketName + '/' : ''}${name}`}
+                  id="app-command"
+                />
               </Row>
             </Col>
           </Row>


### PR DESCRIPTION
Closes #52 

https://user-images.githubusercontent.com/66008060/236514127-060ed47f-8c30-44c0-bf77-dcd0b09f937b.mp4

1. Added a new option to show the bucket name in the install command within search results
2. Modified Search, SearchProcessor, and SearchResult components to incorporate the new option
3. Updated state and callback functions to handle the new option's state
4. Adjusted UI elements to display the new option in the search settings menu



