### PR TITLE
docs: update homepage

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -86,8 +86,8 @@ const Home = (): JSX.Element => {
           (version 5.1 or later) and run:
         </p>
         <SyntaxHighlighter language="powershell">
-          {`> Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Optional: Needed to run a remote script the first time
-> irm get.scoop.sh | iex`}
+          {`> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+> Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression`}
         </SyntaxHighlighter>
         <p className="text-center">
           For advanced installation options, check out the{' '}


### PR DESCRIPTION
The installation instructions in the homepage are not consistent with those in the documentation in the source code repository.

<https://github.com/ScoopInstaller/Scoop/blob/fb3169629fa89b762e39503148cbc96223c68a6a/README.md>

Additionally, the comment about needing to set the execution policy just once has been removed. The user account must be able to run unsigned PowerShell scripts, otherwise an error like this appears when using common `scoop` commands:

![2023-12-09-sfycqp](https://github.com/ScoopInstaller/scoopinstaller.github.io/assets/68171111/18b4e5a7-5d45-44db-85db-7c19448d1a79)
