### PR TITLE
Make the scoop install command copy+paste without editing

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -83,11 +83,11 @@ const Home = (): JSX.Element => {
           >
             PowerShell terminal
           </abbr>{' '}
-          (version 5.1 or later) and run:
+          (version 5.1 or later) and from the PS C:\> prompt, run:
         </p>
         <SyntaxHighlighter language="powershell">
-          {`> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-> Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression`}
+          {`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression`}
         </SyntaxHighlighter>
         <p className="text-center">
           For advanced installation options, check out the{' '}

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -83,7 +83,7 @@ const Home = (): JSX.Element => {
           >
             PowerShell terminal
           </abbr>{' '}
-          (version 5.1 or later) and from the PS C:\> prompt, run:
+          (version 5.1 or later) and from the PS C:\&gt; prompt, run:
         </p>
         <SyntaxHighlighter language="powershell">
           {`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser


### PR DESCRIPTION
Make the required powershell commands copy and pastable without careful selection or editing

The react-syntax-highlighter for powershell is intended for ps1 scripts, not typing into the shell with an extra ">" character there, which breaks the syntax with the error: "> : The term '>' is not recognized as the name of a cmdlet,"