### PR TITLE
chore: Increase GitHub avatar resolution for better logo clarity

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -16,7 +16,7 @@ const NavBar = (): JSX.Element => {
         <Navbar.Brand as={Link} to="/">
           <img
             alt=""
-            src="https://avatars.githubusercontent.com/u/16618068?s=30"
+            src="https://avatars.githubusercontent.com/u/16618068?s=128"
             width="30"
             height="30"
             className="d-inline-block align-top rounded me-2"


### PR DESCRIPTION
#### Motivation
The [GitHub avatar](https://avatars.githubusercontent.com/u/16618068?s=30) appears blurry at 30x30 pixels.
<img width="240" height="50" alt="image" src="https://github.com/user-attachments/assets/fea2abcb-b39e-4d03-97ea-af273dc55abe" />

### Changes
  - Increase GitHub avatar resolution (128*128) for better logo clarity.
    - File size increase from **~1KB** to **2.7KB** should be acceptable for improved quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the navigation brand image to a higher-resolution avatar (larger image served). Visual layout and component behavior remain unchanged; no public interfaces were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->