### PR TITLE
fix: Fix test mocking by deferring env var access

### DIFF
--- a/src/components/SearchProcessor.tsx
+++ b/src/components/SearchProcessor.tsx
@@ -79,8 +79,6 @@ export const sortModes: SortMode[] = [
   },
 ];
 
-const { VITE_APP_AZURESEARCH_URL, VITE_APP_AZURESEARCH_KEY } = import.meta.env;
-
 const SearchProcessor = (props: SearchProcessorProps): JSX.Element => {
   const [resultsCount, setResultsCount] = useState<number>(0);
   const [searching, setSearching] = useState<boolean>(false);
@@ -148,6 +146,8 @@ const SearchProcessor = (props: SearchProcessorProps): JSX.Element => {
     const abortController = new AbortController();
 
     const fetchDataAsync = (abortSignal: AbortSignal): void => {
+      const { VITE_APP_AZURESEARCH_URL, VITE_APP_AZURESEARCH_KEY } = import.meta.env;
+
       setSearching(true);
 
       if (!VITE_APP_AZURESEARCH_URL) {


### PR DESCRIPTION
## Changes
- Move `VITE_APP_AZURESEARCH_*` from module level to function body.
- Allows vi.stubEnv() to properly override environment variables in tests.
- Resolves timing issue where GitHub Actions empty string env prevented mocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized environment variable retrieval timing for improved request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->