### PR TITLE
Use OfficialRepositoryName from index instead of fetching buckets.json

### DIFF
--- a/src/__tests__/mocks/fixtures.ts
+++ b/src/__tests__/mocks/fixtures.ts
@@ -20,6 +20,7 @@ export const mockSearchResponse = {
       Metadata: {
         Repository: 'ScoopInstaller/Main',
         OfficialRepository: true,
+        OfficialRepositoryName: 'main',
         RepositoryStars: 5000,
         BranchName: 'master',
         FilePath: 'bucket/git.json',
@@ -44,6 +45,7 @@ export const mockSearchResponse = {
       Metadata: {
         Repository: 'ScoopInstaller/Extras',
         OfficialRepository: true,
+        OfficialRepositoryName: 'extras',
         RepositoryStars: 3500,
         BranchName: 'master',
         FilePath: 'bucket/github.json',
@@ -78,6 +80,7 @@ export const mockManifest = {
   Metadata: {
     Repository: 'ScoopInstaller/Main',
     OfficialRepository: true,
+    OfficialRepositoryName: 'main',
     RepositoryStars: 5000,
     BranchName: 'master',
     FilePath: 'bucket/nodejs.json',
@@ -116,20 +119,6 @@ export const mockBucketsResponse = {
     },
   ],
 };
-
-// Mock GitHub buckets.json response
-export const mockGitHubBucketsJson = [
-  {
-    name: 'main',
-    repository: 'https://github.com/ScoopInstaller/Main',
-    official: true,
-  },
-  {
-    name: 'extras',
-    repository: 'https://github.com/ScoopInstaller/Extras',
-    official: true,
-  },
-];
 
 // Mock error response
 export const mockErrorResponse = {

--- a/src/components/Search.test.tsx
+++ b/src/components/Search.test.tsx
@@ -122,9 +122,7 @@ beforeEach(() => {
   mockSearchResult.mockClear();
   mockSearchPagination.mockClear();
 
-  (globalThis.fetch as unknown as Mock) = vi.fn().mockResolvedValue({
-    json: vi.fn().mockResolvedValue({ Official: 'main' }),
-  });
+  (globalThis.fetch as unknown as Mock) = vi.fn();
 
   (window as unknown as { scrollTo: () => void }).scrollTo = vi.fn();
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -123,7 +123,6 @@ const Search = (): JSX.Element => {
   );
   const [installBucketName, setInstallBucketName] = useState<boolean>(getInstallBucketNameFromSearchParams());
   const [searchResults, setSearchResults] = useState<SearchResultsJson>();
-  const [officialRepositories, setOfficialRepositories] = useState<{ [key: string]: string }>({});
   const [selectedResult, setSelectedResult] = useState<ManifestJson | null>();
   const [selectedResultId, setSelectedResultId] = useState<string>(getSelectedResultFromSearchParams);
   const selectedResultRef = useRef<HTMLDivElement>(null);
@@ -183,20 +182,6 @@ const Search = (): JSX.Element => {
 
     updateSearchParams(SEARCH_PARAM_SELECTED_RESULT, selectedResultId, false);
   }, [selectedResultId, searchResults, updateSearchParams]);
-
-  useEffect(() => {
-    fetch('https://cdn.jsdelivr.net/gh/ScoopInstaller/Scoop/buckets.json')
-      .then((response) => response.json())
-      .then((response) => {
-        const json = response as { [key: string]: string };
-        const mapping: { [key: string]: string } = {};
-        Object.keys(json).forEach((key) => {
-          mapping[json[key]] = key;
-        });
-        setOfficialRepositories(mapping);
-      })
-      .catch((error) => console.log(error));
-  }, []);
 
   const handleQueryChange = useCallback(
     (newQuery: string): void => {
@@ -318,7 +303,6 @@ const Search = (): JSX.Element => {
                 cardRef={searchResult.id === selectedResultId ? selectedResultRef : undefined}
                 key={searchResult.id}
                 result={searchResult}
-                officialRepositories={officialRepositories}
                 installBucketName={installBucketName}
                 onCopyToClipboard={handleCopyToClipboard}
                 onResultSelected={handleResultSelected}
@@ -351,7 +335,6 @@ const Search = (): JSX.Element => {
           {selectedResult && (
             <SearchResult
               result={selectedResult}
-              officialRepositories={officialRepositories}
               installBucketName={installBucketName}
               onCopyToClipboard={handleCopyToClipboard}
             />

--- a/src/components/SearchProcessor.tsx
+++ b/src/components/SearchProcessor.tsx
@@ -191,6 +191,7 @@ const SearchProcessor = (props: SearchProcessorProps): JSX.Element => {
             'Metadata/Repository',
             'Metadata/FilePath',
             'Metadata/OfficialRepository',
+            'Metadata/OfficialRepositoryName',
             'Metadata/RepositoryStars',
             'Metadata/Committed',
             'Metadata/Sha',

--- a/src/components/SearchResult.test.tsx
+++ b/src/components/SearchResult.test.tsx
@@ -11,14 +11,8 @@ describe('SearchResult', () => {
   const mockOnCopyToClipboard = vi.fn();
   const mockOnResultSelected = vi.fn();
 
-  const officialRepositories = {
-    'ScoopInstaller/Main': 'main',
-    'ScoopInstaller/Extras': 'extras',
-  };
-
   const defaultProps = {
     result: jsonConvert.deserializeObject(mockManifest, ManifestJsonClass),
-    officialRepositories,
     installBucketName: false,
     onCopyToClipboard: mockOnCopyToClipboard,
     onResultSelected: mockOnResultSelected,

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -19,7 +19,6 @@ dayjs.extend(relativeTime);
 
 type SearchResultProps = {
   result: ManifestJson;
-  officialRepositories: { [key: string]: string };
   installBucketName: boolean;
   onCopyToClipboard: (content: string) => void;
   onResultSelected?: (result: ManifestJson) => void;
@@ -27,7 +26,7 @@ type SearchResultProps = {
 };
 
 const SearchResult = (props: SearchResultProps): JSX.Element => {
-  const { result, officialRepositories, installBucketName, onCopyToClipboard, onResultSelected, cardRef } = props;
+  const { result, installBucketName, onCopyToClipboard, onResultSelected, cardRef } = props;
   const homepageRef = useRef<HTMLSpanElement>(null);
   const [homepageTooltipHidden, setHomepageTooltipHidden] = useState<boolean>(false);
 
@@ -113,13 +112,15 @@ const SearchResult = (props: SearchResultProps): JSX.Element => {
 
   // Use known repository name for official repositories and keep only organization+repo for community repositories
   const formattedHighlightedRepository = metadata.repositoryOfficial
-    ? highlightedRepository?.toString().replace(metadata.repository, officialRepositories[metadata.repository])
+    ? highlightedRepository
+        ?.toString()
+        .replace(metadata.repository, metadata.officialRepositoryName || metadata.repository)
     : highlightedRepository?.toString().replace(/^(<mark>|)(?:.*?\/){3}(.+)$/, '$1$2');
 
   const versionPrefix = version.length > 0 && /^\d/.test(version) && 'v';
 
   const bucketName = metadata.repositoryOfficial
-    ? officialRepositories[metadata.repository] ||
+    ? metadata.officialRepositoryName ||
       metadata.repository.substring(metadata.repository.lastIndexOf('/') + 1).toLowerCase()
     : `${extractPathFromUrl(metadata.repository, '_')}`;
   const bucketUrl = metadata.repositoryOfficial ? '' : `${metadata.repository}`;

--- a/src/serialization/MetadataJson.test.ts
+++ b/src/serialization/MetadataJson.test.ts
@@ -14,6 +14,7 @@ describe('MetadataJson', () => {
       const metadata = {
         Repository: 'ScoopInstaller/Main',
         OfficialRepository: true,
+        OfficialRepositoryName: 'main',
         RepositoryStars: 5000,
         BranchName: 'master',
         FilePath: 'bucket/git.json',
@@ -25,6 +26,7 @@ describe('MetadataJson', () => {
 
       expect(result.repository).toBe('ScoopInstaller/Main');
       expect(result.repositoryOfficial).toBe(true);
+      expect(result.officialRepositoryName).toBe('main');
       expect(result.stars).toBe(5000);
       expect(result.branchName).toBe('master');
       expect(result.filePath).toBe('bucket/git.json');
@@ -46,6 +48,7 @@ describe('MetadataJson', () => {
 
       expect(result.repository).toBe('user/repo');
       expect(result.repositoryOfficial).toBe(false);
+      expect(result.officialRepositoryName).toBe('');
       expect(result.stars).toBe(0);
       expect(result.branchName).toBe('');
     });
@@ -66,6 +69,7 @@ describe('MetadataJson', () => {
       expect(result.committed.getFullYear()).toBe(2024);
       expect(result.committed.getMonth()).toBe(0); // January = 0
       expect(result.committed.getDate()).toBe(15);
+      expect(result.officialRepositoryName).toBe('');
     });
   });
 
@@ -74,6 +78,7 @@ describe('MetadataJson', () => {
       const metadata = {
         Repository: 'ScoopInstaller/Main',
         OfficialRepository: true,
+        OfficialRepositoryName: 'main',
         RepositoryStars: 5000,
         FilePath: 'bucket/app.json',
         Committed: '2024-01-01T00:00:00Z',
@@ -83,6 +88,7 @@ describe('MetadataJson', () => {
       const result = jsonConvert.deserializeObject(metadata, MetadataJson);
 
       expect(result.repositoryOfficial).toBe(true);
+      expect(result.officialRepositoryName).toBe('main');
     });
 
     it('should correctly identify non-official repository', () => {
@@ -98,6 +104,7 @@ describe('MetadataJson', () => {
       const result = jsonConvert.deserializeObject(metadata, MetadataJson);
 
       expect(result.repositoryOfficial).toBe(false);
+      expect(result.officialRepositoryName).toBe('');
     });
   });
 
@@ -121,6 +128,7 @@ describe('MetadataJson', () => {
       const metadata = {
         Repository: 'popular/repo',
         OfficialRepository: true,
+        OfficialRepositoryName: 'extras',
         RepositoryStars: 999999,
         FilePath: 'bucket/app.json',
         Committed: '2024-01-01T00:00:00Z',
@@ -130,6 +138,7 @@ describe('MetadataJson', () => {
       const result = jsonConvert.deserializeObject(metadata, MetadataJson);
 
       expect(result.stars).toBe(999999);
+      expect(result.officialRepositoryName).toBe('extras');
     });
   });
 });

--- a/src/serialization/MetadataJson.ts
+++ b/src/serialization/MetadataJson.ts
@@ -10,6 +10,9 @@ class MetadataJson {
   @JsonProperty('OfficialRepository', Boolean)
   repositoryOfficial = false;
 
+  @JsonProperty('OfficialRepositoryName', String, true)
+  officialRepositoryName?: string = '';
+
   @JsonProperty('RepositoryStars', Number)
   stars = 0;
 


### PR DESCRIPTION
#### Changes
Use `OfficialRepositoryName` from the Azure index, instead of retrieving the official bucket name via fetching `buckets.json`

Relates to:
- #116

Relays on:
- https://github.com/ScoopInstaller/scoopinstaller.github.io-indexer/pull/32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Official repository names are now taken directly from search result metadata instead of an external mapping.
  * Search result rendering and selection now rely on metadata-provided repository names for display and bucket/command derivation.

* **Tests**
  * Test fixtures and deserialization tests updated to include and validate the OfficialRepositoryName field.
  * Removed the mocked external buckets fixture and adjusted tests to rely on metadata-driven behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->